### PR TITLE
Add change of levels after cubes cleared

### DIFF
--- a/lib/draw.js
+++ b/lib/draw.js
@@ -7,9 +7,11 @@ function Draw(params) {
   this.qbert      = params['qbert'];
   this.board      = params['board'];
   this.score      = params['score'];
+  this.game       = params['game'];
   this.characters = [this.qbert];
   this.tick       = 0;
   this.enemyFreq  = 500;
+  this.level      = 1;
 }
 
 Draw.prototype.drawFrame = function(){
@@ -18,6 +20,7 @@ Draw.prototype.drawFrame = function(){
   this.drawCharacters();
   this.addEnemies();
   this.tick++;
+  this.checkLevel();
   this.checkEnd();
 };
 
@@ -26,14 +29,8 @@ Draw.prototype.clearContext = function(){
 };
 
 Draw.prototype.updateCharacters = function() {
-  var characters = this.characters;
-  characters.forEach(function(character) {
-    if(character.hasOwnProperty("alive")){
-      if(!character.alive){
-        var index = characters.findIndex(function(){character});
-        characters.splice(index, 1);
-      }
-    }
+  this.characters = this.characters.filter(function(character) {
+    return character.alive === true;
   });
 
   var currentTick = this.tick;
@@ -52,6 +49,21 @@ Draw.prototype.addEnemies = function(){
   if(this.tick !== 0 && this.tick % this.enemyFreq === 0){
     var ball = new Ball({board: this.board, context: this.context});
     this.characters.push(ball);
+  }
+};
+
+Draw.prototype.checkLevel = function() {
+  var cubesRemaining = this.board.cubes.filter(function(cube){
+    return cube.active === false;
+  });
+  if(cubesRemaining.length === 0){
+    this.level++;
+    if (this.enemyFreq > 100) {
+      this.enemyFreq -= 100;
+    } else {
+      this.enemyFreq = this.enemyFreq / 2;
+    }
+    this.game.resetLevel();
   }
 };
 

--- a/lib/game.js
+++ b/lib/game.js
@@ -18,7 +18,8 @@ function Game() {
                                context: this.charContext,
                                canvas:  this.charCanvas,
                                board:   this.board,
-                               score:   this.score
+                               score:   this.score,
+                               game:    this
                              });
 }
 
@@ -40,43 +41,67 @@ Game.prototype.startGame = function() {
 
 Game.prototype.resetGame = function() {
   this.resetCubes();
+  this.resetLives();
+  this.resetQbert();
   this.resetCharacters();
   this.resetScore();
+  this.resetDifficulty();
   this.resetTick();
   this.reanimate();
 };
 
-// get rid of enemies and qbert
-Game.prototype.resetCharacters = function(){
-  this.qbert.lives = 3;
-  this.draw.characters = [this.qbert];
-  this.qbert.setBoard(this.board);
-}
+Game.prototype.resetLevel = function() {
+  this.resetCubes();
+  this.resetQbert();
+  this.resetCharacters();
+  this.resetTick();
+};
 
-// reset blocks
 Game.prototype.resetCubes = function(){
   this.board.cubes.forEach(function(cube){
     cube.active = false;
   });
   this.bgContext.clearRect(0, 0, this.bgCanvas.width, this.bgCanvas.height);
   this.board.drawCubes();
-}
+};
 
-// reanimate
+Game.prototype.resetLives = function() {
+  this.qbert.lives = 3;
+};
+
+Game.prototype.resetQbert = function() {
+  this.qbert.currentPosition  = 0;
+  this.nextPosition           = 0;
+  this.qbert.x                = 450;
+  this.qbert.y                = 180;
+  this.targetX                = 0;
+  this.xVelocity              = 0;
+  this.yVelocity              = 0;
+};
+
+Game.prototype.resetCharacters = function(){
+  this.draw.characters = [this.qbert];
+  this.qbert.setBoard(this.board);
+};
+
 Game.prototype.reanimate = function(){
   var self = this;
   window.requestAnimationFrame(function() {
     self.draw.drawFrame();
   });
+};
 
-}
-// reset score
 Game.prototype.resetScore = function(){
   this.score.reset();
-}
+};
+
+Game.prototype.resetDifficulty = function() {
+  this.draw.level     = 1;
+  this.draw.enemyFreq = 500;
+};
 
 Game.prototype.resetTick = function(){
   this.draw.tick = 0;
-}
+};
 
 module.exports = Game;

--- a/lib/qbert.js
+++ b/lib/qbert.js
@@ -10,6 +10,7 @@ function Qbert(params) {
   this.yVelocity        = 0;
   this.context          = params['context'];
   this.jumping          = false;
+  this.alive            = true;
 }
 
 Qbert.prototype.update = function() {
@@ -30,7 +31,7 @@ Qbert.prototype.update = function() {
     this.xVelocity       = 0;
     this.yVelocity       = 0;
     this.currentPosition = this.nextPosition;
-    
+
     if ( this.board.cubes[this.currentPosition].active === false ) {
       this.board.activateCube(this.currentPosition);
     }


### PR DESCRIPTION
@lingtran @kamiboers 
Add change of levels after cubes are cleared. When that happens:
- Level increases, and the time between enemy spawns decreases.
- The cubes are reset.
- Enemies are cleared.
- Qbert moves to cube 0.

Let me know what you think. We could add a screen display in the middle, but for now I kind of enjoy the continuous play.
