### PR TITLE
Adjust reset method to consistently refer to Qbert

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -72,12 +72,12 @@ Game.prototype.resetLives = function() {
 
 Game.prototype.resetQbert = function() {
   this.qbert.currentPosition  = 0;
-  this.nextPosition           = 0;
+  this.qbert.nextPosition     = 0;
   this.qbert.x                = 325;
   this.qbert.y                = 60;
-  this.targetX                = 0;
-  this.xVelocity              = 0;
-  this.yVelocity              = 0;
+  this.qbert.targetX          = 0;
+  this.qbert.xVelocity        = 0;
+  this.qbert.yVelocity        = 0;
 };
 
 Game.prototype.resetCharacters = function(){


### PR DESCRIPTION
Some variables were note being set because Qbert was not actually referenced.
